### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/POET/Docs          export-ignore
+/POET/Tests         export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/CHANGELOG.md       export-ignore
+/CONTRIBUTING.md    export-ignore
+/phpunit.xml.dist   export-ignore
+/POET.md            export-ignore
+/README.md          export-ignore


### PR DESCRIPTION
This reduces export size for composer installs
